### PR TITLE
Support for ds registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 $ clickplc the-plc-ip-address
 ```
 
-This will print all the X, Y, and DF registers to stdout as JSON. You can pipe
+This will print all the X, Y, DS, and DF registers to stdout as JSON. You can pipe
 this as needed. However, you'll likely want the python functionality below.
 
 ### Python

--- a/clickplc/__init__.py
+++ b/clickplc/__init__.py
@@ -24,6 +24,7 @@ def command_line():
             d = await plc.get('x001-x816')
             d.update(await plc.get('y001-y816'))
             d.update(await plc.get('df1-df500'))
+            d.update(await plc.get('ds1-ds4500'))
             print(json.dumps(d, indent=4))
 
     loop = asyncio.get_event_loop()

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -204,7 +204,7 @@ class ClickPLC(AsyncioModbusClient):
     async def _get_ds(self, start, end):
         """Read DS registers. Called by `get`.
 
-        DS entries start at Modbus address 00000 (00001 in the Click software's
+        DS entries start at Modbus address 0 (1 in the Click software's
         1-indexed notation). Each DS entry takes 16 bits.
         """
         if start < 1 or start > 4500:
@@ -213,7 +213,7 @@ class ClickPLC(AsyncioModbusClient):
             raise ValueError('DS end must be in [1, 4500]')
 
         address = start - 1
-        count = 2 * (1 if end is None else (end - start + 1))
+        count = 1 if end is None else (end - start + 1)
         registers = await self.read_registers(address, count)
         decoder = BinaryPayloadDecoder.fromRegisters(registers,
                                                      byteorder=Endian.Big,


### PR DESCRIPTION
Closes #3 

Working support for DS registers. 

![image](https://user-images.githubusercontent.com/48768927/70833734-5e7cb400-1dad-11ea-9f80-2163b23365ca.png)

```python
async def runds():
    async with ClickPLC('foo-ip-address') as plc:
        await plc.set('ds8', 0)
        await plc.set('ds9', 2)
        await plc.set('ds10', 1)
        print(await plc.get('ds001-ds100'))
```

