### PR TITLE
include more clarity and type checking on data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 clickplc
 ========
 
-Python ≥3.5 driver and command-line tool for [Koyo Ethernet ClickPLCs](https://www.automationdirect.com/adc/Overview/Catalog/Programmable_Controllers/CLICK_Series_PLCs_(Stackable_Micro_Brick)).
+Python ≥3.6 driver and command-line tool for [Koyo Ethernet ClickPLCs](https://www.automationdirect.com/adc/Overview/Catalog/Programmable_Controllers/CLICK_Series_PLCs_(Stackable_Micro_Brick)).
 
 <p align="center">
   <img src="https://www.automationdirect.com/microsites/clickplcs/images/expandedclick.jpg" />

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ The entire API is `get` and `set`, and takes a range of inputs:
 >>> await plc.set('y101', True)  # Sets Y101 to true
 ```
 
-Currently, only X, Y, DS, and DF are supported. I personally haven't needed to
+Currently, only X, Y, C, DS, and DF are supported. I personally haven't needed to
 use the other categories, but they are straightforward to add if needed.

--- a/README.md
+++ b/README.md
@@ -57,5 +57,11 @@ The entire API is `get` and `set`, and takes a range of inputs:
 >>> await plc.set('y101', True)  # Sets Y101 to true
 ```
 
-Currently, only X, Y, C, DS, and DF are supported. I personally haven't needed to
-use the other categories, but they are straightforward to add if needed.
+Currently, only X, Y, C, DS, and DF are supported:
+| x | bool | Input point |
+| y | bool | Output point |
+| c | bool | (C)ontrol relay |
+| df | float | (D)ata register, (f)loating point |
+| ds | int16 | (D)ata register, (s)igned int |
+I personally haven't needed to use the other categories, but they are
+straightforward to add if needed.

--- a/clickplc/__init__.py
+++ b/clickplc/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """
 A Python driver for Koyo ClickPLC ethernet units.
 

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -17,7 +17,13 @@ class ClickPLC(AsyncioModbusClient):
     abstracting corner cases and providing a simple asynchronous interface.
     """
 
-    supported = ['x', 'y', 'c', 'df', 'ds']
+    data_types = {
+        'x': 'bool',    # Input point
+        'y': 'bool',    # Output point
+        'c': 'bool',    # (C)ontrol relay
+        'df': 'float',  # (D)ata register (f)loating point
+        'ds': 'int16',  # (D)ata register (s)igned int
+    }
 
     async def get(self, address):
         """Get variables from the ClickPLC.
@@ -47,7 +53,7 @@ class ClickPLC(AsyncioModbusClient):
 
         if end_index is not None and end_index < start_index:
             raise ValueError("End address must be greater than start address.")
-        if category not in self.supported:
+        if category not in self.data_types:
             raise ValueError("{} currently unsupported.".format(category))
         if end is not None and end[:i].lower() != category:
             raise ValueError("Inter-category ranges are unsupported.")
@@ -73,7 +79,7 @@ class ClickPLC(AsyncioModbusClient):
 
         i = address.index(next(s for s in address if s.isdigit()))
         category, index = address[:i].lower(), int(address[i:])
-        if category not in self.supported:
+        if category not in self.data_types:
             raise ValueError("{} currently unsupported.".format(category))
         return await getattr(self, '_set_' + category)(index, data)
 

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -86,10 +86,11 @@ class ClickPLC(AsyncioModbusClient):
         if category not in self.data_types:
             raise ValueError(f"{category} currently unsupported.")
         data_type = self.data_types[category].rstrip(digits)
-        if isinstance(data, int) and data_type == 'float':
-            data = float(data)
-        if not isinstance(data, pydoc.locate(data_type)):
-            raise ValueError(f"Expected {address} to be a {data_type}.")
+        for datum in data:
+            if isinstance(datum, int) and data_type == 'float':
+                datum = float(datum)
+                if not isinstance(datum, pydoc.locate(data_type)):
+                    raise ValueError(f"Expected {address} as a {data_type}.")
         return await getattr(self, '_set_' + category)(index, data)
 
     async def _get_x(self, start: int, end: int) -> dict:

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -219,7 +219,7 @@ class ClickPLC(AsyncioModbusClient):
         coils = await self.read_coils(start_coil, count)
         if count == 1:
             return coils.bits[0]
-        return {f'c{(start + i}': bit for i, bit in enumerate(coils.bits)}
+        return {f'c{(start + i)}': bit for i, bit in enumerate(coils.bits)}
 
     async def _get_df(self, start: int, end: int) -> Union[dict, float]:
         """Read DF registers. Called by `get`.

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -2,8 +2,10 @@
 A Python driver for Koyo ClickPLC ethernet units.
 
 Distributed under the GNU General Public License v2
-Copyright (C) 2019 NuMat Technologies
+Copyright (C) 2020 NuMat Technologies
 """
+import pydoc
+from string import digits
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder, BinaryPayloadBuilder
 
@@ -81,6 +83,11 @@ class ClickPLC(AsyncioModbusClient):
         category, index = address[:i].lower(), int(address[i:])
         if category not in self.data_types:
             raise ValueError("{} currently unsupported.".format(category))
+        data_type = self.data_types[category].rstrip(digits)
+        if isinstance(data, int) and data_type == 'float':
+            data = float(data)
+        if not isinstance(data, pydoc.locate(data_type)):
+            raise ValueError(f"Expected {address} to be a {data_type}.")
         return await getattr(self, '_set_' + category)(index, data)
 
     async def _get_x(self, start, end):

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -188,7 +188,7 @@ class ClickPLC(AsyncioModbusClient):
             if current > end:
                 break
             elif current % 100 <= 16:
-                output[f'y{current:03}' = bit
+                output[f'y{current:03}'] = bit
             elif current % 100 == 32:
                 current += 100 - 32
             current += 1

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -82,7 +82,7 @@ class ClickPLC(AsyncioModbusClient):
         i = address.index(next(s for s in address if s.isdigit()))
         category, index = address[:i].lower(), int(address[i:])
         if category not in self.data_types:
-            raise ValueError("{} currently unsupported.".format(category))
+            raise ValueError(f"{category} currently unsupported.")
         data_type = self.data_types[category].rstrip(digits)
         if isinstance(data, int) and data_type == 'float':
             data = float(data)
@@ -135,7 +135,7 @@ class ClickPLC(AsyncioModbusClient):
             if current > end:
                 break
             elif current % 100 <= 16:
-                output['x{:03d}'.format(current)] = bit
+                output[f'x{current:03}'] = bit
             elif current % 100 == 32:
                 current += 100 - 32
             current += 1
@@ -186,7 +186,7 @@ class ClickPLC(AsyncioModbusClient):
             if current > end:
                 break
             elif current % 100 <= 16:
-                output['y{:03d}'.format(current)] = bit
+                output[f'y{current:03}' = bit
             elif current % 100 == 32:
                 current += 100 - 32
             current += 1
@@ -217,7 +217,7 @@ class ClickPLC(AsyncioModbusClient):
         coils = await self.read_coils(start_coil, count)
         if count == 1:
             return coils.bits[0]
-        return {'c{:d}'.format(start + i): bit for i, bit in enumerate(coils.bits)}
+        return {f'c{(start + i}': bit for i, bit in enumerate(coils.bits)}
 
     async def _get_df(self, start, end):
         """Read DF registers. Called by `get`.

--- a/clickplc/test_driver.py
+++ b/clickplc/test_driver.py
@@ -6,10 +6,11 @@ from clickplc.mock import ClickPLC
 
 
 class TestClickPLC(TestCase):
-    """Test the functionality of the ClickPLC dirve
+    """Test the functionality of the ClickPLC driver.
 
     Tests use the mocked version of the driver which replaces remote communications
-    with a local data store"""
+    with a local data store
+    """
 
     @classmethod
     def setUp(cls):
@@ -66,17 +67,17 @@ class TestClickPLC(TestCase):
             self.set('foo1', 1)
 
     def xy_error_handling(self, prefix):
-        with self.assertRaisesRegex(ValueError, 'address must be \*01-\*16.'):
+        with self.assertRaisesRegex(ValueError, 'address must be \\*01-\\*16.'):
             self.get(f'{prefix}17')
-        with self.assertRaisesRegex(ValueError, 'address must be in \[001, 816\].'):
+        with self.assertRaisesRegex(ValueError, 'address must be in \\[001, 816\\].'):
             self.get(f'{prefix}1001')
-        with self.assertRaisesRegex(ValueError, 'address must be \*01-\*16.'):
+        with self.assertRaisesRegex(ValueError, 'address must be \\*01-\\*16.'):
             self.get(f'{prefix}1-{prefix}17')
-        with self.assertRaisesRegex(ValueError, 'address must be in \[001, 816\].'):
+        with self.assertRaisesRegex(ValueError, 'address must be in \\[001, 816\\].'):
             self.get(f'{prefix}1-{prefix}1001')
-        with self.assertRaisesRegex(ValueError, 'address must be \*01-\*16.'):
+        with self.assertRaisesRegex(ValueError, 'address must be \\*01-\\*16.'):
             self.set(f'{prefix}17', True)
-        with self.assertRaisesRegex(ValueError, 'address must be in \[001, 816\].'):
+        with self.assertRaisesRegex(ValueError, 'address must be in \\[001, 816\\].'):
             self.set(f'{prefix}1001', True)
         with self.assertRaisesRegex(ValueError, 'Data list longer than available addresses.'):
             self.set(f'{prefix}816', [True, True])
@@ -98,21 +99,21 @@ class TestClickPLC(TestCase):
             self.set('c2000', [True, True])
 
     def test_df_error_handling(self):
-        with self.assertRaisesRegex(ValueError, 'DF must be in \[1, 500\]'):
+        with self.assertRaisesRegex(ValueError, 'DF must be in \\[1, 500\\]'):
             self.get('df501')
-        with self.assertRaisesRegex(ValueError, 'DF end must be in \[1, 500\]'):
+        with self.assertRaisesRegex(ValueError, 'DF end must be in \\[1, 500\\]'):
             self.get('df1-df501')
-        with self.assertRaisesRegex(ValueError, 'DF must be in \[1, 500\]'):
+        with self.assertRaisesRegex(ValueError, 'DF must be in \\[1, 500\\]'):
             self.set('df501', 1.0)
         with self.assertRaisesRegex(ValueError, 'Data list longer than available addresses.'):
             self.set('df500', [1.0, 2.0])
 
     def test_ds_error_handling(self):
-        with self.assertRaisesRegex(ValueError, 'DS must be in \[1, 4500\]'):
+        with self.assertRaisesRegex(ValueError, 'DS must be in \\[1, 4500\\]'):
             self.get('ds4501')
-        with self.assertRaisesRegex(ValueError, 'DS end must be in \[1, 4500\]'):
+        with self.assertRaisesRegex(ValueError, 'DS end must be in \\[1, 4500\\]'):
             self.get('ds1-ds4501')
-        with self.assertRaisesRegex(ValueError, 'DS must be in \[1, 4500\]'):
+        with self.assertRaisesRegex(ValueError, 'DS must be in \\[1, 4500\\]'):
             self.set('ds4501', 1)
         with self.assertRaisesRegex(ValueError, 'Data list longer than available addresses.'):
             self.set('ds4500', [1, 2])

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'console_scripts': [('clickplc = clickplc:command_line')]
     },
     install_requires=[
-        'pymodbus==2.2.0'
+        'pymodbus==2.2.0rc1'
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@
 from platform import python_version
 from setuptools import setup
 
-if python_version() < '3.5':
-    raise ImportError("This module requires Python >=3.5")
+if python_version() < '3.6':
+    raise ImportError("This module requires Python >=3.6")
 
 with open('README.md', 'r') as in_file:
     long_description = in_file.read()
 
 setup(
     name='clickplc',
-    version='0.2.6',
+    version='0.2.7',
     description="Python driver for Koyo Ethernet ClickPLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -22,7 +22,7 @@ setup(
         'console_scripts': [('clickplc = clickplc:command_line')]
     },
     install_requires=[
-        'pymodbus==2.2.0rc1'
+        'pymodbus==2.2.0'
     ],
     license='GPLv2',
     classifiers=[
@@ -31,9 +31,9 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )


### PR DESCRIPTION
I'm trying to make controllers more robust to type mismatches in the configuration while rewriting `interface.py` and `config.py`

[example here](https://github.com/alexrudd2/controllers/blob/solvent-recovery-new/controllers/solvent_recovery/config.py#L69-L76)