### PR TITLE
Support Pymodbus 3.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 build
 dist
 *.egg-info
+.vscode

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ strategy:
       PYTHON_VERSION: '3.9'
     Python310:
       PYTHON_VERSION: '3.10'
+    Python311:
+      PYTHON_VERSION: '3.11'
   maxParallel: 3
 
 steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,8 @@ strategy:
       PYTHON_VERSION: '3.8'
     Python39:
       PYTHON_VERSION: '3.9'
+    Python310:
+      PYTHON_VERSION: '3.10'
   maxParallel: 3
 
 steps:

--- a/clickplc/__init__.py
+++ b/clickplc/__init__.py
@@ -33,7 +33,7 @@ def command_line(args=None):
                 d.update(await plc.get('ctd1-ctd250'))
             print(json.dumps(d, indent=4))
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(get())
 
 

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -4,15 +4,15 @@ A Python driver for Koyo ClickPLC ethernet units.
 Distributed under the GNU General Public License v2
 Copyright (C) 2020 NuMat Technologies
 """
+import copy
 import csv
 import pydoc
-import copy
 from collections import defaultdict
 from string import digits
-from typing import Union, List
+from typing import List, Union
 
 from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadDecoder, BinaryPayloadBuilder
+from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
 
 from clickplc.util import AsyncioModbusClient
 

--- a/clickplc/mock.py
+++ b/clickplc/mock.py
@@ -19,20 +19,21 @@ from pymodbus.register_write_message import WriteMultipleRegistersResponse
 from clickplc.driver import ClickPLC as realClickPLC
 
 
-class AsyncMock(MagicMock):
+class AsyncClientMock(MagicMock):
     """Magic mock that works with async methods."""
 
     async def __call__(self, *args, **kwargs):
         """Convert regular mocks into into an async coroutine."""
-        return super(AsyncMock, self).__call__(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 class ClickPLC(realClickPLC):
     """A version of the driver replacing remote communication with local storage for testing."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.client = AsyncMock()
+    def __init__(self, address, tag_filepath='', timeout=1):
+        self.tags = self._load_tags(tag_filepath)
+        self.active_addresses = self._get_address_ranges(self.tags)
+        self.client = AsyncClientMock()
         self._coils = defaultdict(bool)
         self._discrete_inputs = defaultdict(bool)
         self._registers = defaultdict(bytes)

--- a/clickplc/mock.py
+++ b/clickplc/mock.py
@@ -9,8 +9,10 @@ Copyright (C) 2021 NuMat Technologies
 from collections import defaultdict
 from unittest.mock import MagicMock
 
-from pymodbus.bit_read_message import ReadCoilsResponse, ReadDiscreteInputsResponse
-from pymodbus.bit_write_message import WriteSingleCoilResponse, WriteMultipleCoilsResponse
+from pymodbus.bit_read_message import (ReadCoilsResponse,
+                                       ReadDiscreteInputsResponse)
+from pymodbus.bit_write_message import (WriteMultipleCoilsResponse,
+                                        WriteSingleCoilResponse)
 from pymodbus.register_read_message import ReadHoldingRegistersResponse
 from pymodbus.register_write_message import WriteMultipleRegistersResponse
 

--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -1,7 +1,7 @@
 """Base functionality for modbus communication.
 
 Distributed under the GNU General Public License v2
-Copyright (C) 2019 NuMat Technologies
+Copyright (C) 2022 NuMat Technologies
 """
 import asyncio
 
@@ -15,7 +15,7 @@ import pymodbus.exceptions
 class AsyncioModbusClient(object):
     """A generic asyncio client.
 
-    This expands upon the pymodbus ReconnectionAsyncioModbusTcpClient by
+    This expands upon the pymodbus AsyncModbusTcpClient by
     including standard timeouts, async context manager, and queued requests.
     """
 
@@ -52,7 +52,7 @@ class AsyncioModbusClient(object):
                 raise IOError(f"Could not connect to '{self.ip}'.")
 
     async def read_coils(self, address, count):
-        """Read a modbus coil."""
+        """Read modbus output coils (0 address prefix)."""
         return await self._request('read_coils', address, count)
 
     async def read_registers(self, address, count):
@@ -81,7 +81,7 @@ class AsyncioModbusClient(object):
 
     async def write_register(self, address, value, skip_encode=False):
         """Write a modbus register."""
-        await self._request('write_registers', address, value, skip_encode=skip_encode)
+        await self._request('write_register', address, value, skip_encode=skip_encode)
 
     async def write_registers(self, address, values, skip_encode=False):
         """Write modbus registers.

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,15 @@
 from sys import version_info
 from setuptools import setup
 
-if version_info < (3, 6):
-    raise ImportError("This module requires Python >=3.6 for asyncio support")
-if version_info >= (3, 10):
-    raise ImportError("This module depends on pymodbus, which is incompatible with Python 3.10")
-
+if version_info < (3, 7):
+    raise ImportError("This module requires Python >=3.7.  Use 0.4.1 for Python3.6")
 
 with open('README.md', 'r') as in_file:
     long_description = in_file.read()
 
 setup(
     name='clickplc',
-    version='0.4.1',
+    version='0.6.0',
     description="Python driver for Koyo Ethernet ClickPLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -25,7 +22,10 @@ setup(
         'console_scripts': [('clickplc = clickplc:command_line')]
     },
     install_requires=[
-        'pymodbus>=2.4.0,<3'
+        'pymodbus>=2.4.0,<3; python_version == "3.7"',
+        'pymodbus>=2.4.0; python_version == "3.8"',
+        'pymodbus>=2.4.0; python_version == "3.9"',
+        'pymodbus>=3.0.2; python_version >= "3.10"',
     ],
     extras_require={
         'test': [
@@ -43,10 +43,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Python driver for AutomationDirect (formerly Koyo) Ethernet ClickPLCs."""
 from sys import version_info
+
 from setuptools import setup
 
 if version_info < (3, 7):


### PR DESCRIPTION
See https://github.com/numat/productivity/pull/42

Fortunately the unit tests are much more comprehensive here.

Tested:
- [x] the CLI and a real PLC => works
- [x] CLI and a real PLC with network disconnected  => reconnects OK
- [x] CLI and bad PLC address. => `OSError: Could not connect to '192.168.10.200'.`
- [x] A controller (i.e. initializing the `ClickPLC` class) with a mocked PLC
- [x] A controller with a real PLC => works
- [x] A controller with a bad PLC address => `WARNING asyncio:28 read timed out`
- [x] A controller with a real PLC and a network disconnect => `WARNING asyncio:28 read timed out.` but reconnect works