### PR TITLE
Add type hints and support newer pymodbus

### DIFF
--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -448,16 +448,17 @@ class ClickPLC(AsyncioModbusClient):
         def _pack(values: List[float]):
             builder = BinaryPayloadBuilder(byteorder=Endian.Big,
                                            wordorder=Endian.Little)
-            builder.add_32bit_float(float(value))
+            for value in values:
+                builder.add_32bit_float(float(value))
             return builder.build()
 
         if isinstance(data, list):
             if len(data) > 500 - start:
                 raise ValueError('Data list longer than available addresses.')
-            payload = sum((_pack(d) for d in data), [])
+            payload = _pack(data)
             await self.write_registers(address, payload, skip_encode=True)
         else:
-            await self.write_register(address, _pack(data), skip_encode=True)
+            await self.write_register(address, _pack([data]), skip_encode=True)
 
     async def _set_ds(self, start: int, data: Union[List[int], int]):
         """Set DS registers. Called by `set`.
@@ -468,19 +469,20 @@ class ClickPLC(AsyncioModbusClient):
             raise ValueError('DS must be in [1, 4500]')
         address = (start - 1)
 
-        def _pack(value):
+        def _pack(values: List[int]):
             builder = BinaryPayloadBuilder(byteorder=Endian.Big,
                                            wordorder=Endian.Little)
-            builder.add_16bit_int(int(value))
+            for value in values:
+                builder.add_16bit_int(int(value))
             return builder.build()
 
         if isinstance(data, list):
             if len(data) > 4500 - start:
                 raise ValueError('Data list longer than available addresses.')
-            payload = sum((_pack(d) for d in data), [])
+            payload = _pack(data)
             await self.write_registers(address, payload, skip_encode=True)
         else:
-            await self.write_register(address, _pack(data), skip_encode=True)
+            await self.write_register(address, _pack([data]), skip_encode=True)
 
     def _load_tags(self, tag_filepath: str) -> dict:
         """Load tags from file path.

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -87,9 +87,9 @@ class ClickPLC(AsyncioModbusClient):
                 raise ValueError('An address must be supplied to get if tags were not '
                                  'provided when driver initialized')
             results = {}
-            for category, address in self.active_addresses.items():
+            for category, _address in self.active_addresses.items():
                 results.update(await getattr(self, '_get_' + category)
-                                            (address['min'], address['max']))
+                                            (_address['min'], _address['max']))
             return {tag_name: results[tag_info['id'].lower()]
                     for tag_name, tag_info in self.tags.items()}
 

--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -51,11 +51,11 @@ class AsyncioModbusClient(object):
             except Exception:
                 raise IOError(f"Could not connect to '{self.ip}'.")
 
-    async def read_coils(self, address, count):
+    async def read_coils(self, address: int, count):
         """Read modbus output coils (0 address prefix)."""
         return await self._request('read_coils', address, count)
 
-    async def read_registers(self, address, count):
+    async def read_registers(self, address: int, count):
         """Read modbus registers.
 
         The Modbus protocol doesn't allow responses longer than 250 bytes
@@ -71,19 +71,19 @@ class AsyncioModbusClient(object):
         registers += r.registers
         return registers
 
-    async def write_coil(self, address, value):
+    async def write_coil(self, address: int, value):
         """Write modbus coils."""
         await self._request('write_coil', address, value)
 
-    async def write_coils(self, address, values):
+    async def write_coils(self, address: int, values):
         """Write modbus coils."""
         await self._request('write_coils', address, values)
 
-    async def write_register(self, address, value, skip_encode=False):
+    async def write_register(self, address: int, value, skip_encode=False):
         """Write a modbus register."""
         await self._request('write_register', address, value, skip_encode=skip_encode)
 
-    async def write_registers(self, address, values, skip_encode=False):
+    async def write_registers(self, address: int, values, skip_encode=False):
         """Write modbus registers.
 
         The Modbus protocol doesn't allow requests longer than 250 bytes

--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -8,7 +8,8 @@ import asyncio
 try:
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
 except ImportError:  # 2.4.x - 2.5.x
-    from pymodbus.client.asynchronous.async_io import ReconnectingAsyncioModbusTcpClient
+    from pymodbus.client.asynchronous.async_io import (  # type: ignore
+        ReconnectingAsyncioModbusTcpClient)
 import pymodbus.exceptions
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ docstring-convention = pep257
 # no docstrings in __init__.py
 # line breaks should be before binary operators
 ignore = D104,D107,W503
+
+[mypy]
+check_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'pymodbus>=2.4.0,<3; python_version == "3.7"',
         'pymodbus>=2.4.0; python_version == "3.8"',
         'pymodbus>=2.4.0; python_version == "3.9"',
-        'pymodbus>=3.0.2; python_version >= "3.10"',
+        'pymodbus>=3.0.2,<3.2.0; python_version >= "3.10"',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='clickplc',
-    version='0.6.0',
+    version='0.6.1',
     description="Python driver for Koyo Ethernet ClickPLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name='clickplc',
-    version='0.6.1',
+    version='0.7.0',
     description="Python driver for Koyo Ethernet ClickPLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -26,7 +26,7 @@ setup(
         'pymodbus>=2.4.0,<3; python_version == "3.7"',
         'pymodbus>=2.4.0; python_version == "3.8"',
         'pymodbus>=2.4.0; python_version == "3.9"',
-        'pymodbus>=3.0.2,<3.2.0; python_version >= "3.10"',
+        'pymodbus>=3.0.2,<3.3.0; python_version >= "3.10"',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
- Add/fix more type hints
- Pin pymodbus to <3.2.0, which will break API, for version `0.6.1`
- Support pymodbus 3.2.x in `0.7.0`
