### PR TITLE
Streamline tests for Azure Pipelines and VSCode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    pip install '.[test]'
+    pip install '.[test]' pytest-azurepipelines
   displayName: 'Install dependencies'
 
 - script: |
@@ -42,18 +42,5 @@ steps:
   displayName: 'Check types with mypy'
 
 - script: |
-    cd clickplc
-    pytest --junitxml=../reports/test-coverage.xml  --cov=. --cov-report=xml
+    pytest --junitxml=reports/test-coverage.xml  --cov=. --cov-report=xml
   displayName: 'Run tests'
-
-- task: PublishTestResults@2
-  inputs:
-    testResultsFiles: 'reports/test-coverage.xml'
-    testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
-  condition: succeededOrFailed()
-
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -16,7 +16,7 @@ def plc_driver():
 @pytest.fixture
 def tagged_driver():
     """Confirm the driver correctly initializes with a good tags file."""
-    return ClickPLC('fake ip', 'tests/plc_tags.csv')
+    return ClickPLC('fake ip', 'clickplc/tests/plc_tags.csv')
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def test_driver_cli(capsys):
 @mock.patch('clickplc.ClickPLC', ClickPLC)
 def test_driver_cli_tags(capsys):
     """Confirm the commandline interface works with a tags file."""
-    command_line(['fakeip', 'tests/plc_tags.csv'])
+    command_line(['fakeip', 'clickplc/tests/plc_tags.csv'])
     captured = capsys.readouterr()
     assert 'P_101' in captured.out
     assert 'VAHH_101_OK' in captured.out
@@ -74,7 +74,7 @@ def test_get_tags(tagged_driver, expected_tags):
 def test_unsupported_tags():
     """Confirm the driver detects an improper tags file."""
     with pytest.raises(TypeError, match='unsupported data type'):
-        ClickPLC('fake ip', 'tests/bad_tags.csv')
+        ClickPLC('fake ip', 'clickplc/tests/bad_tags.csv')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
See https://github.com/numat/productivity/pull/58 and 
https://github.com/numat/productivity/pull/57

This should improve the auto-discovery of tests in VSCode (and maybe 
Pycharm?).  It also replaces some annoying Azure Pipelines boilerplate 
with a plugin `pytest-azurepipelines`
