### PR TITLE
Drop 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,21 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         pymodbus-version: ["2.5.3", "3.0.2", "3.1.3", "3.2.2", "3.3.1"]
         exclude:
         - python-version: "3.10"
           pymodbus-version: "2.5.3"
         - python-version: "3.11"
           pymodbus-version: "2.5.3"
-        - python-version: "3.7"
-          pymodbus-version: "3.0.2"
-        - python-version: "3.7"
-          pymodbus-version: "3.1.3"
-        - python-version: "3.7"
-          pymodbus-version: "3.2.2"
-        - python-version: "3.7"
-          pymodbus-version: "3.3.1"
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 clickplc
 ========
 
-Python ≥3.6 driver and command-line tool for [Koyo Ethernet ClickPLCs](https://www.automationdirect.com/adc/Overview/Catalog/Programmable_Controllers/CLICK_Series_PLCs_(Stackable_Micro_Brick)).
+Python ≥3.8 driver and command-line tool for [Koyo Ethernet ClickPLCs](https://www.automationdirect.com/adc/Overview/Catalog/Programmable_Controllers/CLICK_Series_PLCs_(Stackable_Micro_Brick)).
 
 <p align="center">
   <img src="https://www.automationdirect.com/microsites/clickplcs/images/expandedclick.jpg" />

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'console_scripts': [('clickplc = clickplc:command_line')]
     },
     install_requires=[
-        'pymodbus>=2.4.0,<3; python_version == "3.7"',
         'pymodbus>=2.4.0; python_version == "3.8"',
         'pymodbus>=2.4.0; python_version == "3.9"',
         'pymodbus>=3.0.2,<3.4.0; python_version >= "3.10"',
@@ -42,7 +41,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
[EOL as of 2023-06-27](https://devguide.python.org/versions/)
