### PR TITLE
Catch and re-raise CancelledError

### DIFF
--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -126,7 +126,7 @@ class AsyncioModbusClient:
                 return await future(*args, **kwargs)
             except (asyncio.TimeoutError, asyncio.CancelledError,
                     pymodbus.exceptions.ConnectionException) as e:
-                raise TimeoutError(f"Not connected to PLC: {e}")
+                raise TimeoutError(f"Not connected to PLC: {e}") from e
 
     async def _close(self):
         """Close the TCP connection."""

--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -125,8 +125,8 @@ class AsyncioModbusClient:
                     future = getattr(self.client.protocol, method)  # type: ignore
                 return await future(*args, **kwargs)
             except (asyncio.TimeoutError, asyncio.CancelledError,
-                    pymodbus.exceptions.ConnectionException):
-                raise TimeoutError("Not connected to PLC.")
+                    pymodbus.exceptions.ConnectionException) as e:
+                raise TimeoutError(f"Not connected to PLC: {e}")
 
     async def _close(self):
         """Close the TCP connection."""

--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -124,7 +124,8 @@ class AsyncioModbusClient:
                 else:
                     future = getattr(self.client.protocol, method)  # type: ignore
                 return await future(*args, **kwargs)
-            except (asyncio.TimeoutError, pymodbus.exceptions.ConnectionException):
+            except (asyncio.TimeoutError, asyncio.CancelledError,
+                    pymodbus.exceptions.ConnectionException):
                 raise TimeoutError("Not connected to PLC.")
 
     async def _close(self):


### PR DESCRIPTION
See https://github.com/numat/controllers/issues/1596

@juli4nb4dillo 
I prefer this approach to catching `CancelledError` in the controllers.
(1) The docs strongly advise against swallowing `CancelledError`
(2) We know that raising `TimeoutError` works without killing the controller.