### PR TITLE
Remove lock from _connect

### DIFF
--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -52,14 +52,13 @@ class AsyncioModbusClient:
 
     async def _connect(self) -> None:
         """Start asynchronous reconnect loop."""
-        async with self.lock:
-            try:
-                if self.pymodbus30plus:
-                    await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
-                else:  # 2.4.x - 2.5.x
-                    await self.client.start(self.ip)  # type: ignore
-            except Exception:
-                raise OSError(f"Could not connect to '{self.ip}'.")
+        try:
+            if self.pymodbus30plus:
+                await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
+            else:  # 2.4.x - 2.5.x
+                await self.client.start(self.ip)  # type: ignore
+        except Exception:
+            raise OSError(f"Could not connect to '{self.ip}'.")
 
     async def read_coils(self, address: int, count):
         """Read modbus output coils (0 address prefix)."""


### PR DESCRIPTION
See https://github.com/numat/productivity/pull/80

See #76

Lock on `_connect` seems to be redundant, since `_request` already awaits the `connectTask`.
