### PR TITLE
Improve tests and add new datatypes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
         python -m pip install '.[test]'
     - name: Lint with ruff
       run: |
-        ruff .
+        ruff check .
     - name: Check types with mypy
       run: |
          mypy clickplc

--- a/README.md
+++ b/README.md
@@ -57,19 +57,21 @@ The entire API is `get` and `set`, and takes a range of inputs:
 >>> await plc.set('y101', True)  # Sets Y101 to true
 ```
 
-Currently, only X, Y, C, DS, DF, and CTD are supported:
+Currently, the following datatypes are supported:
 
 |  |  |  |
 |---|---|---|
 | x | bool | Input point |
 | y | bool | Output point |
 | c | bool | (C)ontrol relay |
+| t | bool | (T)imer |
+| ct | bool | (C)oun(t)er |
+| ds | int16 | (D)ata register, (s)ingle signed int |
+| dd | int32 | (D)ata register, (d)double signed int |
 | df | float | (D)ata register, (f)loating point |
-| ds | int16 | (D)ata register, (s)igned int |
+| td | int16 | (T)ime (d)elay register |
 | ctd | int32 | (C)oun(t)er Current Values, (d)ouble int |
-
-We personally haven't needed to use the other categories, but they are
-straightforward to add if needed.
+| sd | int16 | (S)ystem (D)ata register |
 
 ### Tags / Nicknames
 

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -367,34 +367,6 @@ class ClickPLC(AsyncioModbusClient):
             return decoder.decode_32bit_int()
         return {f'ctd{n}': decoder.decode_32bit_int() for n in range(start, end + 1)}
 
-    async def _set_x(self, start: int, data: list[bool] | bool):
-        """Set X addresses. Called by `set`.
-
-        For more information on the quirks of X coils, read the `_get_x`
-        docstring.
-        """
-        if start % 100 == 0 or start % 100 > 16:
-            raise ValueError('X start address must be *01-*16.')
-        if start < 1 or start > 816:
-            raise ValueError('X start address must be in [001, 816].')
-        coil = 32 * (start // 100) + start % 100 - 1
-
-        if isinstance(data, list):
-            if len(data) > 16 * (9 - start // 100) - start % 100:
-                raise ValueError('Data list longer than available addresses.')
-            payload = []
-            if (start % 100) + len(data) > 16:
-                i = 17 - (start % 100)
-                payload += data[:i] + [False] * 16
-                data = data[i:]
-            while len(data) > 16:
-                payload += data[:16] + [False] * 16
-                data = data[16:]
-            payload += data
-            await self.write_coils(coil, payload)
-        else:
-            await self.write_coil(coil, data)
-
     async def _set_y(self, start: int, data: list[bool] | bool):
         """Set Y addresses. Called by `set`.
 

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -380,7 +380,7 @@ class ClickPLC(AsyncioModbusClient):
         coil = 8192 + 32 * (start // 100) + start % 100 - 1
 
         if isinstance(data, list):
-            if len(data) > 16 * (9 - start // 100) - start % 100:
+            if len(data) > 16 * (9 - start // 100) - start % 100 + 1:
                 raise ValueError('Data list longer than available addresses.')
             payload = []
             if (start % 100) + len(data) > 16:
@@ -406,7 +406,7 @@ class ClickPLC(AsyncioModbusClient):
         coil = 16384 + start - 1
 
         if isinstance(data, list):
-            if len(data) > (2000 - start):
+            if len(data) > (2000 - start + 1):
                 raise ValueError('Data list longer than available addresses.')
             await self.write_coils(coil, data)
         else:
@@ -438,7 +438,7 @@ class ClickPLC(AsyncioModbusClient):
             return builder.build()
 
         if isinstance(data, list):
-            if len(data) > 500 - start:
+            if len(data) > 500 - start + 1:
                 raise ValueError('Data list longer than available addresses.')
             payload = _pack(data)
             await self.write_registers(address, payload, skip_encode=True)
@@ -466,7 +466,7 @@ class ClickPLC(AsyncioModbusClient):
             return builder.build()
 
         if isinstance(data, list):
-            if len(data) > 4500 - start:
+            if len(data) > 4500 - start + 1:
                 raise ValueError('Data list longer than available addresses.')
             payload = _pack(data)
             await self.write_registers(address, payload, skip_encode=True)

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -1,5 +1,4 @@
 """Test the driver correctly parses a tags file and responds with correct data."""
-import asyncio
 from unittest import mock
 
 import pytest
@@ -10,14 +9,6 @@ from clickplc.mock import ClickPLC
 ADDRESS = 'fakeip'
 # from clickplc.driver import ClickPLC
 # ADDRESS = '172.16.0.168'
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    """Override the default event_loop fixture (which is function-scoped) to be session-scoped."""
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest.fixture(scope='session')
@@ -73,14 +64,14 @@ def test_driver_cli_tags(capsys):
         command_line([ADDRESS, 'tags', 'bogus'])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_unsupported_tags():
     """Confirm the driver detects an improper tags file."""
     with pytest.raises(TypeError, match='unsupported data type'):
         ClickPLC(ADDRESS, 'clickplc/tests/bad_tags.csv')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_tagged_driver(expected_tags):
     """Test a roundtrip with the driver using a tags file."""
     async with ClickPLC(ADDRESS, 'clickplc/tests/plc_tags.csv') as tagged_driver:
@@ -90,7 +81,7 @@ async def test_tagged_driver(expected_tags):
         assert expected_tags == tagged_driver.get_tags()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_y_roundtrip(plc_driver):
     """Confirm y (output bools) are read back correctly after being set."""
     await plc_driver.set('y2', True)
@@ -100,7 +91,7 @@ async def test_y_roundtrip(plc_driver):
     assert expected == await plc_driver.get('y1-y5')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_c_roundtrip(plc_driver):
     """Confirm c bools are read back correctly after being set."""
     await plc_driver.set('c2', True)
@@ -109,7 +100,7 @@ async def test_c_roundtrip(plc_driver):
     assert expected == await plc_driver.get('c1-c5')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_df_roundtrip(plc_driver):
     """Confirm df floats are read back correctly after being set."""
     await plc_driver.set('df1', 0.0)
@@ -118,7 +109,7 @@ async def test_df_roundtrip(plc_driver):
     assert expected == await plc_driver.get('df1-df5')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_ds_roundtrip(plc_driver):
     """Confirm ds ints are read back correctly after being set."""
     await plc_driver.set('ds2', 2)
@@ -127,7 +118,7 @@ async def test_ds_roundtrip(plc_driver):
     assert expected == await plc_driver.get('ds1-ds5')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_get_error_handling(plc_driver):
     """Confirm the driver gives an error on invalid get() calls."""
     with pytest.raises(ValueError, match='An address must be supplied'):
@@ -140,14 +131,14 @@ async def test_get_error_handling(plc_driver):
         await plc_driver.get('c1-x3')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_set_error_handling(plc_driver):
     """Confirm the driver gives an error on invalid set() calls."""
     with pytest.raises(ValueError, match='foo currently unsupported'):
         await plc_driver.set('foo1', 1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 @pytest.mark.parametrize('prefix', ['x', 'y'])
 async def test_get_xy_error_handling(plc_driver, prefix):
     """Ensure errors are handled for invalid get requests of x and y registers."""
@@ -161,7 +152,7 @@ async def test_get_xy_error_handling(plc_driver, prefix):
         await plc_driver.get(f'{prefix}1-{prefix}1001')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_set_y_error_handling(plc_driver):
     """Ensure errors are handled for invalid set requests of y registers."""
     with pytest.raises(ValueError, match=r'address must be \*01-\*16.'):
@@ -172,7 +163,7 @@ async def test_set_y_error_handling(plc_driver):
         await plc_driver.set('y816', [True, True])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_c_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of c registers."""
     with pytest.raises(ValueError, match=r'C start address must be 1-2000.'):
@@ -185,7 +176,7 @@ async def test_c_error_handling(plc_driver):
         await plc_driver.set('c2000', [True, True])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_df_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of df registers."""
     with pytest.raises(ValueError, match=r'DF must be in \[1, 500\]'):
@@ -198,7 +189,7 @@ async def test_df_error_handling(plc_driver):
         await plc_driver.set('df500', [1.0, 2.0])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_ds_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of ds registers."""
     with pytest.raises(ValueError, match=r'DS must be in \[1, 4500\]'):
@@ -211,7 +202,7 @@ async def test_ds_error_handling(plc_driver):
         await plc_driver.set('ds4500', [1, 2])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_ctd_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of ctd registers."""
     with pytest.raises(ValueError, match=r'CTD must be in \[1, 250\]'):
@@ -220,7 +211,7 @@ async def test_ctd_error_handling(plc_driver):
         await plc_driver.get('ctd1-ctd251')
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 @pytest.mark.parametrize('prefix', ['x', 'y', 'c'])
 async def test_bool_typechecking(plc_driver, prefix):
     """Ensure errors are handled for set() requests that should be bools."""
@@ -230,7 +221,7 @@ async def test_bool_typechecking(plc_driver, prefix):
         await plc_driver.set(f'{prefix}1', [1.0, 1])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_df_typechecking(plc_driver):
     """Ensure errors are handled for set() requests that should be floats."""
     await plc_driver.set('df1', 1)
@@ -240,7 +231,7 @@ async def test_df_typechecking(plc_driver):
         await plc_driver.set('df1', [True, True])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope='session')
 async def test_ds_typechecking(plc_driver):
     """Ensure errors are handled for set() requests that should be ints."""
     with pytest.raises(ValueError, match='Expected .+ as a int'):

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -87,14 +87,13 @@ async def test_tagged_driver(tagged_driver, expected_tags):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('prefix', ['x', 'y'])
-async def test_bool_roundtrip(plc_driver, prefix):
-    """Confirm x and y bools are read back correctly after being set."""
-    await plc_driver.set(f'{prefix}2', True)
-    await plc_driver.set(f'{prefix}3', [False, True])
-    expected = {f'{prefix}001': False, f'{prefix}002': True, f'{prefix}003': False,
-                f'{prefix}004': True, f'{prefix}005': False}
-    assert expected == await plc_driver.get(f'{prefix}1-{prefix}5')
+async def test_y_roundtrip(plc_driver):
+    """Confirm y (output bools) are read back correctly after being set."""
+    await plc_driver.set('y2', True)
+    await plc_driver.set('y3', [False, True])
+    expected = {'y001': False, 'y002': True, 'y003': False,
+                'y004': True, 'y005': False}
+    assert expected == await plc_driver.get('y1-y5')
 
 
 @pytest.mark.asyncio
@@ -146,8 +145,8 @@ async def test_set_error_handling(plc_driver):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('prefix', ['x', 'y'])
-async def test_xy_error_handling(plc_driver, prefix):
-    """Ensure errors are handled for invalid requests of x and y registers."""
+async def test_get_xy_error_handling(plc_driver, prefix):
+    """Ensure errors are handled for invalid get requests of x and y registers."""
     with pytest.raises(ValueError, match=r'address must be \*01-\*16.'):
         await plc_driver.get(f'{prefix}17')
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
@@ -156,12 +155,16 @@ async def test_xy_error_handling(plc_driver, prefix):
         await plc_driver.get(f'{prefix}1-{prefix}17')
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
         await plc_driver.get(f'{prefix}1-{prefix}1001')
+
+@pytest.mark.asyncio
+async def test_set_y_error_handling(plc_driver):
+    """Ensure errors are handled for invalid set requests of y registers."""
     with pytest.raises(ValueError, match=r'address must be \*01-\*16.'):
-        await plc_driver.set(f'{prefix}17', True)
+        await plc_driver.set('y17', True)
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
-        await plc_driver.set(f'{prefix}1001', True)
+        await plc_driver.set('y1001', True)
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
-        await plc_driver.set(f'{prefix}816', [True, True])
+        await plc_driver.set('y816', [True, True])
 
 
 @pytest.mark.asyncio

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -84,11 +84,11 @@ async def test_tagged_driver(expected_tags):
 @pytest.mark.asyncio(scope='session')
 async def test_y_roundtrip(plc_driver):
     """Confirm y (output bools) are read back correctly after being set."""
-    await plc_driver.set('y2', True)
-    await plc_driver.set('y3', [False, True])
-    expected = {'y001': False, 'y002': True, 'y003': False,
-                'y004': True, 'y005': False}
-    assert expected == await plc_driver.get('y1-y5')
+    await plc_driver.set('y1', [False, True, False, True])
+    expected = {'y001': False, 'y002': True, 'y003': False, 'y004': True}
+    assert expected == await plc_driver.get('y1-y4')
+    await plc_driver.set('y816', True)
+    assert await plc_driver.get('y816') is True
 
 
 @pytest.mark.asyncio(scope='session')
@@ -98,6 +98,8 @@ async def test_c_roundtrip(plc_driver):
     await plc_driver.set('c3', [False, True])
     expected = {'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': False}
     assert expected == await plc_driver.get('c1-c5')
+    await plc_driver.set('c2000', True)
+    assert await plc_driver.get('c2000') is True
 
 
 @pytest.mark.asyncio(scope='session')
@@ -107,15 +109,19 @@ async def test_df_roundtrip(plc_driver):
     await plc_driver.set('df2', [2.0, 3.0, 4.0, 0.0])
     expected = {'df1': 0.0, 'df2': 2.0, 'df3': 3.0, 'df4': 4.0, 'df5': 0.0}
     assert expected == await plc_driver.get('df1-df5')
+    await plc_driver.set('df500', 1.0)
+    assert await plc_driver.get('df500') == 1.0
 
 
 @pytest.mark.asyncio(scope='session')
 async def test_ds_roundtrip(plc_driver):
     """Confirm ds ints are read back correctly after being set."""
     await plc_driver.set('ds2', 2)
-    await plc_driver.set('ds3', [3, 4])
-    expected = {'ds1': 0, 'ds2': 2, 'ds3': 3, 'ds4': 4, 'ds5': 0}
+    await plc_driver.set('ds3', [-32768, 32767])
+    expected = {'ds1': 0, 'ds2': 2, 'ds3': -32768, 'ds4': 32767, 'ds5': 0}
     assert expected == await plc_driver.get('ds1-ds5')
+    await plc_driver.set('ds4500', 4500)
+    assert await plc_driver.get('ds4500') == 4500
 
 
 @pytest.mark.asyncio(scope='session')

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -41,7 +41,6 @@ def expected_tags():
         'timer': {'address': {'start': 449153}, 'id': 'CTD1', 'type': 'int32'},
     }
 
-
 @mock.patch('clickplc.ClickPLC', ClickPLC)
 def test_driver_cli(capsys):
     """Confirm the commandline interface works without a tags file."""
@@ -50,7 +49,6 @@ def test_driver_cli(capsys):
     assert 'x816' in captured.out
     assert 'c100' in captured.out
     assert 'df100' in captured.out
-
 
 @mock.patch('clickplc.ClickPLC', ClickPLC)
 def test_driver_cli_tags(capsys):
@@ -63,13 +61,11 @@ def test_driver_cli_tags(capsys):
     with pytest.raises(SystemExit):
         command_line([ADDRESS, 'tags', 'bogus'])
 
-
 @pytest.mark.asyncio(scope='session')
 async def test_unsupported_tags():
     """Confirm the driver detects an improper tags file."""
     with pytest.raises(TypeError, match='unsupported data type'):
         ClickPLC(ADDRESS, 'clickplc/tests/bad_tags.csv')
-
 
 @pytest.mark.asyncio(scope='session')
 async def test_tagged_driver(expected_tags):
@@ -80,7 +76,6 @@ async def test_tagged_driver(expected_tags):
         assert state.get('VAH_101_OK')
         assert expected_tags == tagged_driver.get_tags()
 
-
 @pytest.mark.asyncio(scope='session')
 async def test_y_roundtrip(plc_driver):
     """Confirm y (output bools) are read back correctly after being set."""
@@ -89,7 +84,6 @@ async def test_y_roundtrip(plc_driver):
     assert expected == await plc_driver.get('y1-y4')
     await plc_driver.set('y816', True)
     assert await plc_driver.get('y816') is True
-
 
 @pytest.mark.asyncio(scope='session')
 async def test_c_roundtrip(plc_driver):
@@ -101,6 +95,15 @@ async def test_c_roundtrip(plc_driver):
     await plc_driver.set('c2000', True)
     assert await plc_driver.get('c2000') is True
 
+@pytest.mark.asyncio(scope='session')
+async def test_ds_roundtrip(plc_driver):
+    """Confirm ds ints are read back correctly after being set."""
+    await plc_driver.set('ds1', 1)
+    await plc_driver.set('ds3', [-32768, 32767])
+    expected = {'ds1': 1, 'ds2': 0, 'ds3': -32768, 'ds4': 32767, 'ds5': 0}
+    assert expected == await plc_driver.get('ds1-ds5')
+    await plc_driver.set('ds4500', 4500)
+    assert await plc_driver.get('ds4500') == 4500
 
 @pytest.mark.asyncio(scope='session')
 async def test_df_roundtrip(plc_driver):
@@ -112,17 +115,25 @@ async def test_df_roundtrip(plc_driver):
     await plc_driver.set('df500', 1.0)
     assert await plc_driver.get('df500') == 1.0
 
+@pytest.mark.asyncio(scope='session')
+async def test_td_roundtrip(plc_driver):
+    """Confirm td ints are read back correctly after being set."""
+    await plc_driver.set('td1', 1)
+    await plc_driver.set('td2', [2, -32768, 32767, 0])
+    expected = {'td1': 1, 'td2': 2, 'td3': -32768, 'td4': 32767, 'td5': 0}
+    assert expected == await plc_driver.get('td1-td5')
+    await plc_driver.set('td500', 500)
+    assert await plc_driver.get('td500') == 500
 
 @pytest.mark.asyncio(scope='session')
-async def test_ds_roundtrip(plc_driver):
-    """Confirm ds ints are read back correctly after being set."""
-    await plc_driver.set('ds2', 2)
-    await plc_driver.set('ds3', [-32768, 32767])
-    expected = {'ds1': 0, 'ds2': 2, 'ds3': -32768, 'ds4': 32767, 'ds5': 0}
-    assert expected == await plc_driver.get('ds1-ds5')
-    await plc_driver.set('ds4500', 4500)
-    assert await plc_driver.get('ds4500') == 4500
-
+async def test_dd_roundtrip(plc_driver):
+    """Confirm dd double ints are read back correctly after being set."""
+    await plc_driver.set('dd1', 1)
+    await plc_driver.set('dd3', [-2**31, 2**31 - 1])
+    expected = {'dd1': 1, 'dd2': 0, 'dd3': -2**31, 'dd4': 2**31 - 1, 'dd5': 0}
+    assert expected == await plc_driver.get('dd1-dd5')
+    await plc_driver.set('dd1000', 1000)
+    assert await plc_driver.get('dd1000') == 1000
 
 @pytest.mark.asyncio(scope='session')
 async def test_get_error_handling(plc_driver):
@@ -136,13 +147,11 @@ async def test_get_error_handling(plc_driver):
     with pytest.raises(ValueError, match='Inter-category ranges are unsupported'):
         await plc_driver.get('c1-x3')
 
-
 @pytest.mark.asyncio(scope='session')
 async def test_set_error_handling(plc_driver):
     """Confirm the driver gives an error on invalid set() calls."""
     with pytest.raises(ValueError, match='foo currently unsupported'):
         await plc_driver.set('foo1', 1)
-
 
 @pytest.mark.asyncio(scope='session')
 @pytest.mark.parametrize('prefix', ['x', 'y'])
@@ -157,7 +166,6 @@ async def test_get_xy_error_handling(plc_driver, prefix):
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
         await plc_driver.get(f'{prefix}1-{prefix}1001')
 
-
 @pytest.mark.asyncio(scope='session')
 async def test_set_y_error_handling(plc_driver):
     """Ensure errors are handled for invalid set requests of y registers."""
@@ -168,18 +176,33 @@ async def test_set_y_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('y816', [True, True])
 
-
 @pytest.mark.asyncio(scope='session')
 async def test_c_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of c registers."""
     with pytest.raises(ValueError, match=r'C start address must be 1-2000.'):
         await plc_driver.get('c2001')
-    with pytest.raises(ValueError, match=r'C end address must be >start and <2000.'):
+    with pytest.raises(ValueError, match=r'C end address must be >start and <=2000.'):
         await plc_driver.get('c1-c2001')
     with pytest.raises(ValueError, match=r'C start address must be 1-2000.'):
         await plc_driver.set('c2001', True)
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('c2000', [True, True])
+
+@pytest.mark.asyncio(scope='session')
+async def test_t_error_handling(plc_driver):
+    """Ensure errors are handled for invalid requests of t registers."""
+    with pytest.raises(ValueError, match=r'T start address must be 1-500.'):
+        await plc_driver.get('t501')
+    with pytest.raises(ValueError, match=r'T end address must be >start and <=500.'):
+        await plc_driver.get('t1-t501')
+
+@pytest.mark.asyncio(scope='session')
+async def test_ct_error_handling(plc_driver):
+    """Ensure errors are handled for invalid requests of ct registers."""
+    with pytest.raises(ValueError, match=r'CT start address must be 1-250.'):
+        await plc_driver.get('ct251')
+    with pytest.raises(ValueError, match=r'CT end address must be >start and <=250.'):
+        await plc_driver.get('ct1-ct251')
 
 
 @pytest.mark.asyncio(scope='session')
@@ -194,7 +217,6 @@ async def test_df_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('df500', [1.0, 2.0])
 
-
 @pytest.mark.asyncio(scope='session')
 async def test_ds_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of ds registers."""
@@ -207,6 +229,25 @@ async def test_ds_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('ds4500', [1, 2])
 
+@pytest.mark.asyncio(scope='session')
+async def test_dd_error_handling(plc_driver):
+    """Ensure errors are handled for invalid requests of dd registers."""
+    with pytest.raises(ValueError, match=r'DD must be in \[1, 1000\]'):
+        await plc_driver.get('dd1001')
+    with pytest.raises(ValueError, match=r'DD end must be in \[1, 1000\]'):
+        await plc_driver.get('dd1-dd1001')
+    with pytest.raises(ValueError, match=r'DD must be in \[1, 1000\]'):
+        await plc_driver.set('dd1001', 1)
+    with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
+        await plc_driver.set('dd1000', [1, 2])
+
+@pytest.mark.asyncio(scope='session')
+async def test_td_error_handling(plc_driver):
+    """Ensure errors are handled for invalid requests of td registers."""
+    with pytest.raises(ValueError, match=r'TD must be in \[1, 500\]'):
+        await plc_driver.get('td501')
+    with pytest.raises(ValueError, match=r'TD end must be in \[1, 500\]'):
+        await plc_driver.get('td1-td501')
 
 @pytest.mark.asyncio(scope='session')
 async def test_ctd_error_handling(plc_driver):
@@ -216,16 +257,14 @@ async def test_ctd_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'CTD end must be in \[1, 250\]'):
         await plc_driver.get('ctd1-ctd251')
 
-
 @pytest.mark.asyncio(scope='session')
-@pytest.mark.parametrize('prefix', ['x', 'y', 'c'])
+@pytest.mark.parametrize('prefix', ['y', 'c'])
 async def test_bool_typechecking(plc_driver, prefix):
     """Ensure errors are handled for set() requests that should be bools."""
     with pytest.raises(ValueError, match='Expected .+ as a bool'):
         await plc_driver.set(f'{prefix}1', 1)
     with pytest.raises(ValueError, match='Expected .+ as a bool'):
         await plc_driver.set(f'{prefix}1', [1.0, 1])
-
 
 @pytest.mark.asyncio(scope='session')
 async def test_df_typechecking(plc_driver):
@@ -236,13 +275,13 @@ async def test_df_typechecking(plc_driver):
     with pytest.raises(ValueError, match='Expected .+ as a float'):
         await plc_driver.set('df1', [True, True])
 
-
 @pytest.mark.asyncio(scope='session')
-async def test_ds_typechecking(plc_driver):
+@pytest.mark.parametrize('prefix', ['ds', 'dd'])
+async def test_ds_dd_typechecking(plc_driver, prefix):
     """Ensure errors are handled for set() requests that should be ints."""
     with pytest.raises(ValueError, match='Expected .+ as a int'):
-        await plc_driver.set('ds1', 1.0)
+        await plc_driver.set(f'{prefix}1', 1.0)
     with pytest.raises(ValueError, match='Expected .+ as a int'):
-        await plc_driver.set('ds1', True)
+        await plc_driver.set(f'{prefix}1', True)
     with pytest.raises(ValueError, match='Expected .+ as a int'):
-        await plc_driver.set('ds1', [True, True])
+        await plc_driver.set(f'{prefix}1', [True, True])

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -1,4 +1,5 @@
 """Test the driver correctly parses a tags file and responds with correct data."""
+import asyncio
 from unittest import mock
 
 import pytest
@@ -6,18 +7,24 @@ import pytest
 from clickplc import command_line
 from clickplc.mock import ClickPLC
 
+ADDRESS = 'fakeip'
+# from clickplc.driver import ClickPLC
+# ADDRESS = '172.16.0.168'
 
-@pytest.fixture
-def plc_driver():
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Override the default event_loop fixture (which is function-scoped) to be session-scoped."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope='session')
+async def plc_driver():
     """Confirm the driver correctly initializes without a tags file."""
-    return ClickPLC('fake ip')
-
-
-@pytest.fixture
-def tagged_driver():
-    """Confirm the driver correctly initializes with a good tags file."""
-    return ClickPLC('fake ip', 'clickplc/tests/plc_tags.csv')
-
+    async with ClickPLC(ADDRESS) as c:
+        yield c
 
 @pytest.fixture
 def expected_tags():
@@ -47,7 +54,7 @@ def expected_tags():
 @mock.patch('clickplc.ClickPLC', ClickPLC)
 def test_driver_cli(capsys):
     """Confirm the commandline interface works without a tags file."""
-    command_line(['fakeip'])
+    command_line([ADDRESS])
     captured = capsys.readouterr()
     assert 'x816' in captured.out
     assert 'c100' in captured.out
@@ -57,33 +64,30 @@ def test_driver_cli(capsys):
 @mock.patch('clickplc.ClickPLC', ClickPLC)
 def test_driver_cli_tags(capsys):
     """Confirm the commandline interface works with a tags file."""
-    command_line(['fakeip', 'clickplc/tests/plc_tags.csv'])
+    command_line([ADDRESS, 'clickplc/tests/plc_tags.csv'])
     captured = capsys.readouterr()
     assert 'P_101' in captured.out
     assert 'VAHH_101_OK' in captured.out
     assert 'TI_101' in captured.out
     with pytest.raises(SystemExit):
-        command_line(['fakeip', 'tags', 'bogus'])
-
-
-def test_get_tags(tagged_driver, expected_tags):
-    """Confirm that the driver returns correct values on get() calls."""
-    assert expected_tags == tagged_driver.get_tags()
-
-
-def test_unsupported_tags():
-    """Confirm the driver detects an improper tags file."""
-    with pytest.raises(TypeError, match='unsupported data type'):
-        ClickPLC('fake ip', 'clickplc/tests/bad_tags.csv')
+        command_line([ADDRESS, 'tags', 'bogus'])
 
 
 @pytest.mark.asyncio
-async def test_tagged_driver(tagged_driver, expected_tags):
+async def test_unsupported_tags():
+    """Confirm the driver detects an improper tags file."""
+    with pytest.raises(TypeError, match='unsupported data type'):
+        ClickPLC(ADDRESS, 'clickplc/tests/bad_tags.csv')
+
+
+@pytest.mark.asyncio
+async def test_tagged_driver(expected_tags):
     """Test a roundtrip with the driver using a tags file."""
-    await tagged_driver.set('VAH_101_OK', True)
-    state = await tagged_driver.get()
-    assert state.get('VAH_101_OK')
-    assert expected_tags.keys() == state.keys()
+    async with ClickPLC(ADDRESS, 'clickplc/tests/plc_tags.csv') as tagged_driver:
+        await tagged_driver.set('VAH_101_OK', True)
+        state = await tagged_driver.get()
+        assert state.get('VAH_101_OK')
+        assert expected_tags == tagged_driver.get_tags()
 
 
 @pytest.mark.asyncio
@@ -108,8 +112,8 @@ async def test_c_roundtrip(plc_driver):
 @pytest.mark.asyncio
 async def test_df_roundtrip(plc_driver):
     """Confirm df floats are read back correctly after being set."""
-    await plc_driver.set('df2', 2.0)
-    await plc_driver.set('df3', [3.0, 4.0])
+    await plc_driver.set('df1', 0.0)
+    await plc_driver.set('df2', [2.0, 3.0, 4.0, 0.0])
     expected = {'df1': 0.0, 'df2': 2.0, 'df3': 3.0, 'df4': 4.0, 'df5': 0.0}
     assert expected == await plc_driver.get('df1-df5')
 
@@ -155,6 +159,7 @@ async def test_get_xy_error_handling(plc_driver, prefix):
         await plc_driver.get(f'{prefix}1-{prefix}17')
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
         await plc_driver.get(f'{prefix}1-{prefix}1001')
+
 
 @pytest.mark.asyncio
 async def test_set_y_error_handling(plc_driver):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ ignore_missing_imports = True
 
 [tool:pytest]
 addopts = --cov=clickplc
+asyncio_mode = auto

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ setup(
     extras_require={
         'test': [
             'pytest',
+            'pytest-asyncio>=0.23.7,<=0.23.9',
             'pytest-cov',
-            'pytest-asyncio',
+            'pytest-xdist',
             'mypy==1.10.0',
             'ruff==0.4.2',
         ],

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ with open('README.md') as in_file:
 
 setup(
     name='clickplc',
-    version='0.8.3',
+    version='0.9.0',
     description="Python driver for Koyo Ethernet ClickPLCs.",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/numat/clickplc/',
+    url='https://github.com/alexrudd2/clickplc/',
     author='Patrick Fuller',
     author_email='pat@numat-tech.com',
     maintainer='Alex Ruddick',


### PR DESCRIPTION
Add the following datatypes:
| name | type | description | note | 
|---------|--------|----------------|-------|
| t | bool | (T)imer | Closes #21 |
| ct | bool | (C)oun(t)er | |
| dd | int32 | (D)ata register, (d)double signed int | |
| td | int16 | (T)ime (d)elay register | |
| sd | int16 | (S)ystem (D)ata register | Closes #13 |

Make more rigorous tests, and fix a couple off-by-one errors at the last registers of each type.

Remove `set_x()` which could never work (`X` is read-only).

More precisely define working `pytest-asyncio` versions.